### PR TITLE
Updating to Guzzle 2.0

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $builder = new TreeBuilder();
-        
+
         $builder
             ->root('guzzle')
                 ->children()
@@ -22,17 +22,11 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('configuration_file')
                                 ->defaultValue('%kernel.root_dir%/config/webservices.xml')
                             ->end()
-                            ->arrayNode('cache')
-                                ->children()
-                                    ->scalarNode('adapter')->end()
-                                    ->scalarNode('driver')->end()
-                                ->end()
-                            ->end()
                         ->end()
                     ->end()
                 ->end()
             ->end();
-        
-        return $builder;                    
+
+        return $builder;
     }
 }

--- a/DependencyInjection/DdeboerGuzzleExtension.php
+++ b/DependencyInjection/DdeboerGuzzleExtension.php
@@ -19,48 +19,12 @@ class DdeboerGuzzleExtension extends Extension
             new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.xml');
-        
+
         $processor = new Processor();
         $configuration = new Configuration();
         $config = $processor->processConfiguration($configuration, $configs);
-     
+
         $container->setParameter('guzzle.service_builder.configuration_file',
                 $config['service_builder']['configuration_file']);
-
-        if (isset($config['service_builder']['cache'])) {
-            $this->loadCacheAdapter($config['service_builder']['cache'], $container);
-        }
-    }
-    
-    protected function loadCacheAdapter($config, ContainerBuilder $container)
-    {
-        if (isset($config['adapter'])) {
-            switch ($config['adapter']) {
-                case 'doctrine':
-                    switch ($config['driver']) {
-                        case 'apc':
-                        case 'array':
-                        case 'xcache':
-                            $cacheDefinition = new Definition(
-                                '%'.sprintf('guzzle.cache.driver.%s.class', $config['driver']).'%');
-                            $cacheDefinition->setPublic(false);
-                            $container->setDefinition('guzzle.cache.class', $cacheDefinition);
-                           
-                            break;
-
-                        default:
-                            break;
-                    }
-                case 'zend':
-                    $adapterDefinition = new Definition(
-                        '%'.sprintf('guzzle.cache.adapter.%s.class', $config['adapter']).'%');
-                    $adapterDefinition->addArgument(new Reference('guzzle.cache.class'));
-
-                default:
-                    break;
-            }
-            $adapterDefinition->setPublic(false);
-            $container->setDefinition('guzzle.cache.adapter', $adapterDefinition);
-        }
     }
 }

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # GuzzleBundle
-## Introduction 
+## Introduction
 GuzzleBundle is a Symfony2 bundle for integrating the [Guzzle PHP library](http://github.com/guzzle/guzzle) in your project.
 
 It’s not quite finished.
@@ -18,56 +18,53 @@ Add Guzzle and Ddeboer namespace to your autoloader:
 
     // app/autoload.php
     $loader->registerNamespaces(array(
-		// ...
-		'Guzzle'           => __DIR__.'/../vendor/guzzle/src',
-		'Ddeboer'          => __DIR__.'/../vendor/bundles',
-		// ...
-	));
-    
+        // ...
+        'Guzzle'           => __DIR__.'/../vendor/guzzle/src',
+        'Ddeboer'          => __DIR__.'/../vendor/bundles',
+        // ...
+    ));
+
 ## Application kernel
 Add GuzzleBundle to your application kernel:
 
     // app/AppKernel.php
-	public function registerBundles()
-	{
-		// ...
-		new Ddeboer\GuzzleBundle\DdeboerGuzzleBundle(),
-		// ...
-	}
-	
+    public function registerBundles()
+    {
+        // ...
+        new Ddeboer\GuzzleBundle\DdeboerGuzzleBundle(),
+        // ...
+    }
+
 ## Configure the Guzzle service builder
 
-	// app/config/config.yml
-	ddeboer_guzzle: 
+    // app/config/config.yml
+    ddeboer_guzzle:
     service_builder:
       configuration_file: "%kernel.root_dir%/config/webservices.xml"
-      cache: 
-        adapter: doctrine
-        driver: apc
 
-And add a Guzzle services configuration file. See the [Guzzle documentation](http://guzzlephp.org/docs/tour/using_services/#describe-clients-using-your-services-xml-file).
-	
-	// app/config/webservices.xml
-	<?xml version="1.0" ?>
-	<guzzle>
-	    <clients>
-	        <!-- Abstract service to store AWS account credentials -->
-	        <client name="abstract.aws">
-	            <param name="access_key" value="12345" />
-	            <param name="secret_key" value="abcd" />
-	        </client>
-	        <!-- Amazon S3 client that extends the abstract client -->
-	        <client name="s3" classs="Guzzle.Aws.S3.S3Client" extends="abstract.aws">
-	            <param name="devpay_product_token" value="XYZ" />
-	            <param name="devpay_user_token" value="123" />
-	        </client>
-	        <client name="simple_db" class="Guzzle.Aws.SimpleDb.SimpleDbClient" extends="abstract.aws" />
-	        <client name="sqs" class="Guzzle.Aws.Sqs.SqsClient" extends="abstract.aws" />
-	        <!-- Unfuddle client -->
-	        <client name="unfuddle" class="Guzzle.Unfuddle.UnfuddleClient">
-	            <param name="username" value="test-user" />
-	            <param name="password" value="my-password" />
-	            <param name="subdomain" value="my-subdomain" />
-	        </client>
-	    </clients>
-	</guzzle>
+And add a Guzzle services configuration file. See the [Guzzle documentation](http://guzzlephp.org/tour/using_services.html#instantiating-web-service-clients-using-a-servicebuilder).
+
+    // app/config/webservices.xml
+    <?xml version="1.0" ?>
+    <guzzle>
+        <clients>
+            <!-- Abstract service to store AWS account credentials -->
+            <client name="abstract.aws">
+                <param name="access_key" value="12345" />
+                <param name="secret_key" value="abcd" />
+            </client>
+            <!-- Amazon S3 client that extends the abstract client -->
+            <client name="s3" classs="Guzzle.Aws.S3.S3Client" extends="abstract.aws">
+                <param name="devpay_product_token" value="XYZ" />
+                <param name="devpay_user_token" value="123" />
+            </client>
+            <client name="simple_db" class="Guzzle.Aws.SimpleDb.SimpleDbClient" extends="abstract.aws" />
+            <client name="sqs" class="Guzzle.Aws.Sqs.SqsClient" extends="abstract.aws" />
+            <!-- Unfuddle client -->
+            <client name="unfuddle" class="Guzzle.Unfuddle.UnfuddleClient">
+                <param name="username" value="test-user" />
+                <param name="password" value="my-password" />
+                <param name="subdomain" value="my-subdomain" />
+            </client>
+        </clients>
+    </guzzle>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,17 +7,11 @@
     <parameters>
         <parameter key="guzzle.service_builder.class">Guzzle\Service\ServiceBuilder</parameter>
         <parameter key="guzzle.service_builder_factory.class">Ddeboer\GuzzleBundle\ServiceBuilderFactory</parameter>
-        <parameter key="guzzle.cache_adapter.class"></parameter>
-        <parameter key="guzzle.cache.adapter.doctrine.class">Guzzle\Common\Cache\DoctrineCacheAdapter</parameter>
-        <parameter key="guzzle.cache.adapter.zend.class">Guzzle\Common\Cache\ZendCacheAdapter</parameter>
-        <parameter key="guzzle.cache.driver.apc.class">Doctrine\Common\Cache\ApcCache</parameter>
-        <parameter key="guzzle.cache.driver.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
     </parameters>
 
     <services>
         <service id="guzzle.service_builder" class="%guzzle.service_builder.class%" factory-class="%guzzle.service_builder.class%" factory-method="factory">
             <argument type="string" id="guzzle.service_builder.configuration_file">%guzzle.service_builder.configuration_file%</argument>
-            <argument type="service" id="guzzle.cache.adapter" on-invalid="ignore" />
         </service>
     </services>
 


### PR DESCRIPTION
Guzzle 2.0 was released the other day.  There's no longer caching built into the service builder (though it's now serializable if you need to cache it).  I haven't tested this, but I wanted to give you a good starting point for updating the bundle.

Thanks!
