### PR TITLE
Change Log, Plugin and Cache namespace for Guzzle 3.x

### DIFF
--- a/DataCollector/HttpDataCollector.php
+++ b/DataCollector/HttpDataCollector.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-use Guzzle\Common\Log\LogAdapterInterface;
+use Guzzle\Log\LogAdapterInterface;
 
 /**
  * MessageDataCollector.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,9 +8,8 @@
         <parameter key="guzzle.service_builder.class">Guzzle\Service\Builder\ServiceBuilder</parameter>
         <parameter key="guzzle.service_builder_factory.class">Guzzle\Service\Builder\ServiceBuilder</parameter>
 
-        <parameter key="guzzle.plugin.service_builder.class">Guzzle\Service\Plugin\PluginCollectionPlugin</parameter>
         <parameter key="guzzle.plugin.data_collector.class">Ddeboer\GuzzleBundle\Guzzle\Http\Plugin\DataCollectorPlugin</parameter>
-        <parameter key="guzzle.plugin.log.class">Guzzle\Http\Plugin\LogPlugin</parameter>
+        <parameter key="guzzle.plugin.log.class">Guzzle\Plugin\Log\LogPlugin</parameter>
         <parameter key="guzzle.plugin.log.monolog.adapter.class">Guzzle\Log\MonologLogAdapter</parameter>
         <parameter key="guzzle.plugin.log.array.adapter.class">Guzzle\Log\ArrayLogAdapter</parameter>
         <parameter key="guzzle.data_collector.class">Ddeboer\GuzzleBundle\DataCollector\HttpDataCollector</parameter>
@@ -27,15 +26,11 @@
             <argument type="string" id="guzzle.service_builder.configuration_file">%guzzle.service_builder.configuration_file%</argument>
 
             <call method="addSubscriber">
-                <argument type="service" id="guzzle.plugin.service_builder" />
-            </call>
-        </service>
-
-        <service id="guzzle.plugin.service_builder" class="%guzzle.plugin.service_builder.class%" public="false">
-            <argument type="collection">
                 <argument type="service" id="guzzle.plugin.log.array" />
+            </call>
+            <call method="addSubscriber">
                 <argument type="service" id="guzzle.plugin.log.monolog" />
-            </argument>
+            </call>
         </service>
 
         <service id="guzzle.plugin.log.monolog" class="%guzzle.plugin.log.class%" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,8 +16,8 @@
         <parameter key="guzzle.data_collector.class">Ddeboer\GuzzleBundle\DataCollector\HttpDataCollector</parameter>
 
         <parameter key="guzzle.cache_adapter.class"></parameter>
-        <parameter key="guzzle.cache.adapter.doctrine.class">Guzzle\Common\Cache\DoctrineCacheAdapter</parameter>
-        <parameter key="guzzle.cache.adapter.zend.class">Guzzle\Common\Cache\Zf1CacheAdapter</parameter>
+        <parameter key="guzzle.cache.adapter.doctrine.class">Guzzle\Cache\DoctrineCacheAdapter</parameter>
+        <parameter key="guzzle.cache.adapter.zend.class">Guzzle\Cache\Zf1CacheAdapter</parameter>
         <parameter key="guzzle.cache.driver.apc.class">Doctrine\Common\Cache\ApcCache</parameter>
         <parameter key="guzzle.cache.driver.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
     </parameters>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,8 +11,8 @@
         <parameter key="guzzle.plugin.service_builder.class">Guzzle\Service\Plugin\PluginCollectionPlugin</parameter>
         <parameter key="guzzle.plugin.data_collector.class">Ddeboer\GuzzleBundle\Guzzle\Http\Plugin\DataCollectorPlugin</parameter>
         <parameter key="guzzle.plugin.log.class">Guzzle\Http\Plugin\LogPlugin</parameter>
-        <parameter key="guzzle.plugin.log.monolog.adapter.class">Guzzle\Common\Log\MonologLogAdapter</parameter>
-        <parameter key="guzzle.plugin.log.array.adapter.class">Guzzle\Common\Log\ArrayLogAdapter</parameter>
+        <parameter key="guzzle.plugin.log.monolog.adapter.class">Guzzle\Log\MonologLogAdapter</parameter>
+        <parameter key="guzzle.plugin.log.array.adapter.class">Guzzle\Log\ArrayLogAdapter</parameter>
         <parameter key="guzzle.data_collector.class">Ddeboer\GuzzleBundle\DataCollector\HttpDataCollector</parameter>
 
         <parameter key="guzzle.cache_adapter.class"></parameter>


### PR DESCRIPTION
In Guzzle 3.x the Log classes have been moved from Guzzle\Common\Log to Guzzle\Log, the Cache classes have been moved from Guzzle\Common\Cache to Guzzle\Cache and the Plugin classes have been moved from Guzzle\Http\Plugin to Guzzle\Plugin

Additionally, the CollectionPlugin has been removed and plugins have to be added individually

Edited two files to reflect this change
